### PR TITLE
Strip out script tags from embedded js source

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -45,8 +45,12 @@ class AssetEntry {
         }
     }
     private applyScript(tag: HTMLScriptElement) {
+        const start = /<script>/gi;
+        const end = /<\/script>gi;
         tag.removeAttribute('src');
-        tag.innerHTML = this.content.toString();
+        var js = this.content.toString();
+        js = content.replace(start,' ').replace(end,' ');
+        tag.innerHTML = content;
         return tag;
     }
 }

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -49,8 +49,8 @@ class AssetEntry {
         const end = /<\/script>gi;
         tag.removeAttribute('src');
         var js = this.content.toString();
-        js = content.replace(start,' ').replace(end,' ');
-        tag.innerHTML = content;
+        js = content.replace(start,'').replace(end,'');
+        tag.innerHTML = js;
         return tag;
     }
 }


### PR DESCRIPTION
Work around for #2 this replaces <script> and <\script> from the js that is embedded in the html files